### PR TITLE
add checkbox to move the related membership contributions,  add `allow Move Membership permission`

### DIFF
--- a/CRM/LCD/MoveMembership/BAO/MoveMembership.php
+++ b/CRM/LCD/MoveMembership/BAO/MoveMembership.php
@@ -11,6 +11,29 @@ class CRM_LCD_MoveMembership_BAO_MoveMembership {
         'id' => $params['membership_id'],
         'contact_id' => $params['contact_id'],
       ));
+
+Civi::log()->debug('movemembership params ' . print_r($params, true));
+
+      if ($params['change_contributions']) {
+        $contributions = civicrm_api3('MembershipPayment', 'get', [
+          'sequential' => 1,
+          'return' => ['contribution_id'],
+          'membership_id' => $params['membership_id'],
+        ]);
+Civi::log()->debug('movemembership contributions ' . print_r($contributions, true));
+
+        if ($contributions['count'] > 1) {
+          foreach($contributions['values'] as $contribution) {
+            $contributionParams = [
+              'change_contact_id' => $params['contact_id'],
+              'contact_id' => $params['contact_id'],
+              'contribution_id' => $contribution['contribution_id'],
+              'current_contact_id' => $params['current_contact_id'],
+            ];
+            CRM_LCD_MoveContrib_BAO_MoveContrib::moveContribution($contributionParams);
+          }
+        }
+      }
     }
     catch (CiviCRM_API3_Exception $e) {}
 

--- a/CRM/LCD/MoveMembership/Form/MoveMembership.php
+++ b/CRM/LCD/MoveMembership/Form/MoveMembership.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_LCD_MoveMembership_ExtensionUtil as E;
+
 require_once 'CRM/Core/Form.php';
 
 /**
@@ -15,27 +17,35 @@ class CRM_LCD_MoveMembership_Form_MoveMembership extends CRM_Core_Form {
   public function preProcess() {
     //check for edit permission
     if (!CRM_Core_Permission::checkActionPermission('CiviMember', CRM_Core_Action::UPDATE)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     parent::preProcess();
   }
 
   public function buildQuickForm() {
-    $this->_membershipId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $membershipID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    $this->_contactId = civicrm_api3('membership', 'getvalue', array(
-      'id' => $this->_membershipId,
+    $contactID = civicrm_api3('membership', 'getvalue', [
+      'id' => $membershipID,
       'return' => 'contact_id',
-    ));
+    ]);
+
 
     //get current contact name.
-    $this->assign('currentContactName', CRM_Contact_BAO_Contact::displayName($this->_contactId));
+    $this->assign('currentContactName', CRM_Contact_BAO_Contact::displayName($contactID));
 
     $this->addEntityRef('change_contact_id', ts('Select Contact'));
-    $this->add('hidden', 'contact_id', '', array('id' => 'contact_id'));
-    $this->add('hidden', 'membership_id', $this->_membershipId, array('id' => 'membership_id'));
-    $this->add('hidden', 'current_contact_id', $this->_contactId, array('id' => 'current_contact_id'));
-    $this->assign('contactId', $this->_contactId);
+
+    if (class_exists('CRM_LCD_MoveContrib_BAO_MoveContrib')) {
+      $this->add('checkbox', 'change_contributions', E::ts('Move all associated contributions'));
+    } else {
+      $this->add('hidden', 'change_contributions', '', ['id' => 'change_contributions']);
+    }
+
+    $this->add('hidden', 'contact_id', '', ['id' => 'contact_id']);
+    $this->add('hidden', 'membership_id', $membershipID, ['id' => 'membership_id']);
+    $this->add('hidden', 'current_contact_id', $contactID, ['id' => 'current_contact_id']);
+    $this->assign('contactId', $contactID);
 
     // export form elements
     $this->assign('elementNames', $this->getRenderableElementNames());
@@ -60,15 +70,16 @@ class CRM_LCD_MoveMembership_Form_MoveMembership extends CRM_Core_Form {
       'contact_id' => $values['change_contact_id'],
       'membership_id' => $values['membership_id'],
       'current_contact_id' => $values['current_contact_id'],
+      'change_contributions' => $values['change_contributions'],
     );
 
     $result = CRM_LCD_MoveMembership_BAO_MoveMembership::moveMembership($params);
 
     if ($result) {
-      CRM_Core_Session::setStatus(ts('Membership moved successfully.'), ts('Moved'), 'success');
+      CRM_Core_Session::setStatus(E::ts('Membership moved successfully.'), E::ts('Moved'), 'success');
     }
     else {
-      CRM_Core_Session::setStatus(ts('Unable to move membership.'), ts('Error'), 'error');
+      CRM_Core_Session::setStatus(E::ts('Unable to move membership.'), ts('Error'), 'error');
     }
 
     parent::postProcess();

--- a/CRM/LCD/MoveMembership/Form/Task.php
+++ b/CRM/LCD/MoveMembership/Form/Task.php
@@ -1,35 +1,6 @@
 <?php
-/*
- +--------------------------------------------------------------------+
- | CiviCRM version 4.7                                                |
- +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2017                                |
- +--------------------------------------------------------------------+
- | This file is a part of CiviCRM.                                    |
- |                                                                    |
- | CiviCRM is free software; you can copy, modify, and distribute it  |
- | under the terms of the GNU Affero General Public License           |
- | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
- |                                                                    |
- | CiviCRM is distributed in the hope that it will be useful, but     |
- | WITHOUT ANY WARRANTY; without even the implied warranty of         |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
- | See the GNU Affero General Public License for more details.        |
- |                                                                    |
- | You should have received a copy of the GNU Affero General Public   |
- | License and the CiviCRM Licensing Exception along                  |
- | with this program; if not, contact CiviCRM LLC                     |
- | at info[AT]civicrm[DOT]org. If you have questions about the        |
- | GNU Affero General Public License or the licensing of CiviCRM,     |
- | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
- +--------------------------------------------------------------------+
- */
 
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2017
- */
+use CRM_LCD_MoveMembership_ExtensionUtil as E;
 
 /**
  * This class provides the functionality to delete a group of memberships.
@@ -44,7 +15,7 @@ class CRM_LCD_MoveMembership_Form_Task extends CRM_Member_Form_Task {
   public function preProcess() {
     //check for delete
     if (!CRM_Core_Permission::checkActionPermission('CiviMember', CRM_Core_Action::UPDATE)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     parent::preProcess();
   }
@@ -54,6 +25,13 @@ class CRM_LCD_MoveMembership_Form_Task extends CRM_Member_Form_Task {
    */
   public function buildQuickForm() {
     $this->addEntityRef('change_contact_id', ts('Select Contact'));
+
+    if (class_exists('CRM_LCD_MoveContrib_BAO_MoveContrib')) {
+      $this->add('checkbox', 'change_contributions', E::ts('Move all associated contributions'));
+    } else {
+      $this->add('hidden', 'change_contributions', '', ['id' => 'change_contributions']);
+    }
+
     $count = count($this->_memberIds);
     $this->assign('count', $count);
 
@@ -93,6 +71,7 @@ class CRM_LCD_MoveMembership_Form_Task extends CRM_Member_Form_Task {
         'contact_id' => $values['change_contact_id'],
         'membership_id' => $membershipId,
         'current_contact_id' => $currentContactId,
+        'change_contributions' => $values['change_contributions'],
       );
 
       if (CRM_LCD_MoveMembership_BAO_MoveMembership::moveMembership($params)) {
@@ -104,14 +83,14 @@ class CRM_LCD_MoveMembership_Form_Task extends CRM_Member_Form_Task {
     }
 
     if ($moved) {
-      CRM_Core_Session::setStatus(ts('%count membership moved.', array(
+      CRM_Core_Session::setStatus(E::ts('%count membership moved.', array(
         'plural' => '%count memberships moved.',
         'count' => $moved
       )), ts('Moved'), 'success');
     }
 
     if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be moved.', array(
+      CRM_Core_Session::setStatus(E::ts('1 could not be moved.', array(
         'plural' => '%count could not be moved.',
         'count' => $failed
       )), ts('Error'), 'error');

--- a/movemembership.php
+++ b/movemembership.php
@@ -2,6 +2,8 @@
 
 require_once 'movemembership.civix.php';
 
+use CRM_LCD_MoveMembership_ExtensionUtil as E;
+
 /**
  * Implements hook_civicrm_config().
  *
@@ -30,37 +32,42 @@ function movemembership_civicrm_enable() {
 }
 
 function movemembership_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
-  /*Civi::log()->debug('movemembership_civicrm_links', array(
-    '$op' => $op,
-    '$objectName' => $objectName,
-    '$objectId' => $objectId,
-    '$links' => $links,
-    '$mask' => $mask,
-    '$values' => $values,
-  ));*/
-
-  if ($op == 'membership.tab.row' && $objectName == 'Membership') {
+  if ($op === 'membership.tab.row' && $objectName === 'Membership' && CRM_Core_Permission::check('allow Move Membership')) {
     $links[] = array(
-      'name' => 'Move',
-      'url' => 'civicrm/movemembership',
+      'name' => E::ts('Move'),
+      'url' => 'civicrm/movemembership/task?reset=1&task_item=move',
       'qs' => 'id=%%id%%',
-      'title' => 'Move',
-      //'bit' => NULL,
+      'title' => E::ts('Move'),
+      'key' => 'move',
+      'weight' => 130,
     );
   }
 }
 
 function movemembership_civicrm_searchTasks($objectType, &$tasks) {
-  /*Civi::log()->debug('movemembership_civicrm_searchTasks', array(
-    '$objectType' => $objectType,
-    '$tasks' => $tasks,
-  ));*/
-
-  if ($objectType == 'membership') {
-    $tasks[] = array(
-      'title' => 'Move memberships',
+  if ($objectType === 'membership' && CRM_Core_Permission::check('allow Move Membership')) {
+    $tasks[] = [
+      'title' => E::ts('Move Membership'),
       'class' => 'CRM_LCD_MoveMembership_Form_Task',
       'result' => TRUE,
-    );
+      'is_single_mode' => TRUE,
+      'title_single_mode' => E::ts('Move'),
+      'name' => E::ts('Move'),
+      'url' => 'civicrm/membership/task?reset=1&task_item=move',
+      'key' => 'move',
+      'weight' => 130,
+    ];
   }
+}
+
+/**
+ *Implementation of hook_civicrm_permission
+ * @param array $permissions
+ */
+function movemembership_civicrm_permission(&$permissions) {
+  $permissions['allow Move Membership'] = [
+    'label' => E::ts('CiviCRM: Allow Move Memberships'),
+    'description' => E::ts('Allow Move Membership')
+   ];
+
 }


### PR DESCRIPTION
I added an option to move membership related contributions if [movecontrib extension](https://github.com/lcdservices/biz.lcdservices.movecontrib) is installed: I thought of using the static method `CRM_LCD_MoveContrib_BAO_MoveContrib::moveContribution` instead of writing a similar function.

Then I added the `allow Move Membership permission` and prepared for translating.